### PR TITLE
Fix. uninitialized constant RubygemsCheckReplacementVulnerability::CLI::Pathname (NameError)

### DIFF
--- a/lib/rubygems_check_replacement_vulnerability/cli.rb
+++ b/lib/rubygems_check_replacement_vulnerability/cli.rb
@@ -4,6 +4,7 @@ require "thor"
 module RubygemsCheckReplacementVulnerability
   require "yaml"
   require "json"
+  require "pathname"
 
   class CLI < Thor
     include ShellMethods

--- a/lib/rubygems_check_replacement_vulnerability/version.rb
+++ b/lib/rubygems_check_replacement_vulnerability/version.rb
@@ -1,3 +1,3 @@
 module RubygemsCheckReplacementVulnerability
-  VERSION = "0.1.0"
+  VERSION = "0.1.1.beta1"
 end


### PR DESCRIPTION
```
$  rubygems_check_replacement_vulnerability verify_gem --name=rspec-temp_dir --repo-url=git@github.com:sue445/rspec-temp_dir.git
Unpacked gem: '/var/folders/mx/mmp8n_lx48v8_fr294_zjggw0000gn/T/gem-20160414-26623-uzprty/rspec-temp_dir-0.0.1'
/Users/sue445/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rubygems_check_replacement_vulnerability-0.1.0/lib/rubygems_check_replacement_vulnerability/cli.rb:105:in `block (2 levels) in verify?': uninitialized constant RubygemsCheckReplacementVulnerability::CLI::Pathname (NameError)
    from /Users/sue445/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rubygems_check_replacement_vulnerability-0.1.0/lib/rubygems_check_replacement_vulnerability/cli.rb:104:in `chdir'
    from /Users/sue445/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rubygems_check_replacement_vulnerability-0.1.0/lib/rubygems_check_replacement_vulnerability/cli.rb:104:in `block in verify?'
    from /Users/sue445/.rbenv/versions/2.3.0/lib/ruby/2.3.0/tmpdir.rb:89:in `mktmpdir'
```
